### PR TITLE
複数タームを区切るカンマの文字色の標準を白にしてはどうか

### DIFF
--- a/src/css/app/block-styles/_wp-block-post-terms.scss
+++ b/src/css/app/block-styles/_wp-block-post-terms.scss
@@ -8,5 +8,9 @@
 			padding: calc(var(--unitone--s-2) / 2) var(--unitone--s-2);
 			text-decoration: none;
 		}
+		
+		> span {
+			color: var(--wp--preset--color--white);
+		}
 	}
 }


### PR DESCRIPTION
複数タームを選択している投稿の際に区切りとしてカンマが出力されますが、そちらにスタイルが当たっていなかったので、ちょっと勝手に書いてみました。

デフォルトで `background-color: var(--wp--preset--color--black);` を当てられているので、対称色として `var(--wp--preset--color--white)` を `span` に指定してみました。

詳細度的に `.wp-block-post-terms__separator` で指定するべきかもしれませんが、キタジマさん的な書き方がわからなかったので、まずはタグ指定します。

採用いただけるようであれば良しなに変えてやってくださいませ。