### PR TITLE
`unitone_display_deprecated_parts` を  `gutenberg_register_block_core_template_part` の後に発火するように。

### DIFF
--- a/inc/templates.php
+++ b/inc/templates.php
@@ -303,4 +303,4 @@ function unitone_display_deprecated_parts() {
 		)
 	);
 }
-add_action( 'init', 'unitone_display_deprecated_parts' );
+add_action( 'init', 'unitone_display_deprecated_parts', 21 );


### PR DESCRIPTION
参考: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/comments/index.php

Gutenberg ではコアブロック群の登録が init の 20 で設定されているので、unitone でのブロック登録の後にコアのブロックの登録が行われ、Notice が発生します。

そのため、ブロックの登録を、21 以降で行うように fix しました。