### PR TITLE
`unitone/with-lineage-toolbar` の挙動を修整

### DIFF
--- a/src/js/editor/plugins/lineage-toolbar/index.js
+++ b/src/js/editor/plugins/lineage-toolbar/index.js
@@ -40,7 +40,6 @@ const withLineageToolbar = createHigherOrderComponent( ( BlockEdit ) => {
 		const { clientId } = props;
 
 		const { selectBlock } = useDispatch( blockEditorStore );
-
 		const { getBlock, getBlockParents } = useSelect( blockEditorStore );
 		const { getBlockType } = useSelect( blocksStore );
 
@@ -60,14 +59,16 @@ const withLineageToolbar = createHigherOrderComponent( ( BlockEdit ) => {
 		);
 
 		const parentClientId = getBlockParents( clientId, true )?.[ 0 ];
-
 		const onSelectParentBlock = useCallback( () => {
 			selectBlock( parentClientId );
-		}, [ parentClientId ] );
+		}, [ parentClientId, selectBlock ] );
 
+		const firstInnerBlockId = innerBlocks?.[ 0 ]?.clientId;
 		const onSelectChildBlock = useCallback( () => {
-			selectBlock( innerBlocks[ 0 ].clientId );
-		}, [ innerBlocks?.[ 0 ]?.clientId ] );
+			if ( firstInnerBlockId ) {
+				selectBlock( firstInnerBlockId );
+			}
+		}, [ firstInnerBlockId, selectBlock ] );
 
 		const childrenDropdownMenuControls = useMemo( () => {
 			return innerBlocks.map( ( innerBlock ) => {
@@ -77,7 +78,7 @@ const withLineageToolbar = createHigherOrderComponent( ( BlockEdit ) => {
 					onClick: () => selectBlock( innerBlock.clientId ),
 				};
 			} );
-		}, [ clientId ] );
+		}, [ innerBlocks, selectBlock ] );
 
 		return (
 			<>


### PR DESCRIPTION
>  The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.

の警告が出ていたので useSelect 周りの記述を見直した。useSelect の値が変わることで再レンダリングの原因になっている様子なので、useSelect 内での計算を、useSelect からメソッドを取り出して外側で計算するように変更。